### PR TITLE
Doesn't work with node-jquery

### DIFF
--- a/lib/vcr.js
+++ b/lib/vcr.js
@@ -70,6 +70,18 @@ VCRConstructor.Context = function VCRContext(name, config) {
           self.extend(fakeXHR, response);
         }
         typeof callback == 'function' && callback();
+      },
+      setRequestHeader: function(header, value) {
+        return value;
+      },
+      getRequestHeader: function(name) {
+        return '';
+      },
+      getResponseHeader: function(header) {
+        return '';
+      },
+      getAllResponseHeaders: function() {
+        return '';
       }
     });
   };


### PR DESCRIPTION
Hi, 

I'm trying to use vcr with node-jquery (https://github.com/coolaj86/node-jquery), however i'm unable to hook vcr into $.ajaxSettings.xhr.

``` javascript
$ = require('jquery')
XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest
VCR = require('vcr')

VCR.configure(function(c){
  c.hookInto = XMLHttpRequest
  c.cassetteLibraryDir = "cassettes";
})

VCR.useCassette('test', function(v){
  $.ajaxSettings.xhr = function(){
    return new v.XMLHttpRequest()
  }

  $.getJSON('https://api.github.com/users/octocat/orgs').
    complete(function(res){ console.log('COMPLETE', res) }).
    error(function(res){ console.log("ERORR", res) }).
    success(function(res){ console.log('SUCCESS', res) })
})
```

Following code returns : 

ERORR { readyState: 0,
  setRequestHeader: [Function],
  getAllResponseHeaders: [Function],
  getResponseHeader: [Function],
  overrideMimeType: [Function],
  abort: [Function],
  state: [Function],
  always: [Function],
  then: [Function],
  promise: [Function],
  pipe: [Function],
  done: [Function],
  fail: [Function],
  progress: [Function],
  success: [Function],
  error: [Function],
  complete: [Function],
  statusCode: [Function],
  status: 0,
  statusText: 'TypeError: Cannot read property \'headers\' of undefined' }

I've create example repo so you can reproduce this issue : https://github.com/kbackowski/vcr.js.node-jquery.

After cloning just run :

$ npm install
$ node index.js

Any ideas on how to make it working ? I've also tried downgrading node-jquery to 1.7.2.
