### PR TITLE
Prepend request url with only when it's defined

### DIFF
--- a/lib/vcr.js
+++ b/lib/vcr.js
@@ -61,7 +61,7 @@ VCRConstructor.Context = function VCRContext(name, config) {
         var fakeXHR = this;
 
         if(!response) {
-          XHR.open(self.type, config.host + self.url);
+          XHR.open(self.type, (config.host || '') + self.url);
           XHR.send(data);
           XHR.onreadystatechange = function() {
             if(this.readyState === 4) {


### PR DESCRIPTION
Currently when host is not defined vcr will try to make invalid request i.e. "nullhttp://example.com"
